### PR TITLE
Dapper column name matching

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddSingleton<DapperContext>();
 builder.Services.AddScoped<IPlanetRepository, PlanetRepository>();
+Dapper.DefaultTypeMap.MatchNamesWithUnderscores = true;
 
 var app = builder.Build();
 


### PR DESCRIPTION
enable dapper to match column names with underscores to the PascalCase models